### PR TITLE
Abstract `Logger` as trait using 'given' macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ def program(using Logger[IO]): IO[Unit] =
 
 val main: IO[Unit] = 
   for
-    given Logger[IO]  <- Logger.makeIoLogger(consoleOutput)
+    given Logger[IO]  <- DefaultLogger.makeIo(consoleOutput)
     _                 <- program
   yield ()
 ```
@@ -61,10 +61,10 @@ and running it yields:
 ```scala
 import cats.effect.unsafe.implicits.global
 main.unsafeRunSync()
-// 2021-12-23 10:45:47 [DEBUG] repl.MdocSession$.App: This is some debug (.:27)
-// 2021-12-23 10:45:47 [INFO ] repl.MdocSession$.App: HEY! (.:28)
-// 2021-12-23 10:45:47 [WARN ] repl.MdocSession$.App: I'm warning you (.:29)
-// 2021-12-23 10:45:47 [ERROR] repl.MdocSession$.App: I give up (.:30)
+// 2021-12-23 11:00:00 [DEBUG] repl.MdocSession$.App: This is some debug (.:27)
+// 2021-12-23 11:00:00 [INFO ] repl.MdocSession$.App: HEY! (.:28)
+// 2021-12-23 11:00:00 [WARN ] repl.MdocSession$.App: I'm warning you (.:29)
+// 2021-12-23 11:00:00 [ERROR] repl.MdocSession$.App: I give up (.:30)
 ```
 
 
@@ -74,7 +74,7 @@ We can also re-use the program and add context to our logger:
 import Logger.*
 val mainWithContext: IO[Unit] = 
   for
-    given Logger[IO]  <- Logger.makeIoLogger(consoleOutput)
+    given Logger[IO]  <- DefaultLogger.makeIo(consoleOutput)
     _                 <- program.withLogContext("trace-id", "4d334544-6462-43fa-b0b1-12846f871573")
     _                 <- Logger[IO].info("Now the context is gone")
   yield ()
@@ -84,11 +84,11 @@ And running with context yields:
 
 ```scala
 mainWithContext.unsafeRunSync()
-// 2021-12-23 10:45:47 [DEBUG] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: This is some debug (.:27)
-// 2021-12-23 10:45:47 [INFO ] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: HEY! (.:28)
-// 2021-12-23 10:45:47 [WARN ] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: I'm warning you (.:29)
-// 2021-12-23 10:45:47 [ERROR] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: I give up (.:30)
-// 2021-12-23 10:45:47 [INFO ] repl.MdocSession$.App: Now the context is gone (.:61)
+// 2021-12-23 11:00:00 [DEBUG] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: This is some debug (.:27)
+// 2021-12-23 11:00:00 [INFO ] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: HEY! (.:28)
+// 2021-12-23 11:00:00 [WARN ] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: I'm warning you (.:29)
+// 2021-12-23 11:00:00 [ERROR] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: I give up (.:30)
+// 2021-12-23 11:00:00 [INFO ] repl.MdocSession$.App: Now the context is gone (.:61)
 ```
 
 # Can I use SLF4J?
@@ -122,7 +122,7 @@ To use this program with woof
 import org.legogroup.woof.slf4j.*
 val mainSlf4j: IO[Unit] = 
   for
-    woofLogger  <- Logger.makeIoLogger(consoleOutput)
+    woofLogger  <- DefaultLogger.makeIo(consoleOutput)
     _           <- woofLogger.registerSlf4j
     _           <- programWithSlf4j
   yield ()
@@ -132,8 +132,8 @@ and running it:
 
 ```scala
 mainSlf4j.unsafeRunSync()
-// 2021-12-23 10:45:47 [INFO ] repl.MdocSession$App: Hello from SLF4j! (MdocSession$App.scala:81)
-// 2021-12-23 10:45:47 [WARN ] repl.MdocSession$App: This is not the pure woof. (MdocSession$App.scala:82)
+// 2021-12-23 11:00:00 [INFO ] repl.MdocSession$App: Hello from SLF4j! (MdocSession$App.scala:81)
+// 2021-12-23 11:00:00 [WARN ] repl.MdocSession$App: This is not the pure woof. (MdocSession$App.scala:82)
 ```
 ## Limitations of SLF4J bindings
 
@@ -170,7 +170,7 @@ import cats.syntax.option.given
 
 val mainHttp4s: IO[Unit] = 
   for
-    given Logger[IO]  <- Logger.makeIoLogger(consoleOutput)
+    given Logger[IO]  <- DefaultLogger.makeIo(consoleOutput)
     maybeResponse     <- CorrelationIdMiddleware.middleware[IO]()(routes).run(Request[IO]()).value
     responseHeaders   =  maybeResponse.map(_.headers).orEmpty
     _                 <- Logger[IO].info(s"Got response headers: $responseHeaders")
@@ -184,6 +184,6 @@ the correlation ID is also returned in the header of the response.
 
 ```scala
 mainHttp4s.unsafeRunSync()
-// 2021-12-23 10:45:47 [INFO ] X-Trace-Id=9b343a7d-90c5-4078-bbd6-42bd756bc15c repl.MdocSession$.App: I got a request with trace id! :D (.:121)
-// 2021-12-23 10:45:47 [INFO ] repl.MdocSession$.App: Got response headers: Headers(X-Trace-Id: 9b343a7d-90c5-4078-bbd6-42bd756bc15c) (.:142)
+// 2021-12-23 11:00:00 [INFO ] X-Trace-Id=13af5dfc-72df-48e2-aae2-aff1563d09e6 repl.MdocSession$.App: I got a request with trace id! :D (.:121)
+// 2021-12-23 11:00:00 [INFO ] repl.MdocSession$.App: Got response headers: Headers(X-Trace-Id: 13af5dfc-72df-48e2-aae2-aff1563d09e6) (.:142)
 ```

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ libraryDependencies ++= Seq(
 
 ```scala
 import cats.effect.IO
-import org.legogroup.woof.*
+import org.legogroup.woof.{given, *}
 
 val consoleOutput: Output[IO] = new Output[IO]:
   def output(str: String)      = IO.delay(println(str))
@@ -61,10 +61,10 @@ and running it yields:
 ```scala
 import cats.effect.unsafe.implicits.global
 main.unsafeRunSync()
-// 2021-12-16 14:42:44 [DEBUG] repl.MdocSession$.App: This is some debug (.:27)
-// 2021-12-16 14:42:44 [INFO ] repl.MdocSession$.App: HEY! (.:28)
-// 2021-12-16 14:42:44 [WARN ] repl.MdocSession$.App: I'm warning you (.:29)
-// 2021-12-16 14:42:44 [ERROR] repl.MdocSession$.App: I give up (.:30)
+// 2021-12-23 10:45:47 [DEBUG] repl.MdocSession$.App: This is some debug (.:27)
+// 2021-12-23 10:45:47 [INFO ] repl.MdocSession$.App: HEY! (.:28)
+// 2021-12-23 10:45:47 [WARN ] repl.MdocSession$.App: I'm warning you (.:29)
+// 2021-12-23 10:45:47 [ERROR] repl.MdocSession$.App: I give up (.:30)
 ```
 
 
@@ -84,11 +84,11 @@ And running with context yields:
 
 ```scala
 mainWithContext.unsafeRunSync()
-// 2021-12-16 14:42:44 [DEBUG] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: This is some debug (.:27)
-// 2021-12-16 14:42:44 [INFO ] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: HEY! (.:28)
-// 2021-12-16 14:42:44 [WARN ] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: I'm warning you (.:29)
-// 2021-12-16 14:42:44 [ERROR] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: I give up (.:30)
-// 2021-12-16 14:42:44 [INFO ] repl.MdocSession$.App: Now the context is gone (.:61)
+// 2021-12-23 10:45:47 [DEBUG] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: This is some debug (.:27)
+// 2021-12-23 10:45:47 [INFO ] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: HEY! (.:28)
+// 2021-12-23 10:45:47 [WARN ] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: I'm warning you (.:29)
+// 2021-12-23 10:45:47 [ERROR] trace-id=4d334544-6462-43fa-b0b1-12846f871573 repl.MdocSession$.App: I give up (.:30)
+// 2021-12-23 10:45:47 [INFO ] repl.MdocSession$.App: Now the context is gone (.:61)
 ```
 
 # Can I use SLF4J?
@@ -132,8 +132,8 @@ and running it:
 
 ```scala
 mainSlf4j.unsafeRunSync()
-// 2021-12-16 14:42:44 [INFO ] repl.MdocSession$App: Hello from SLF4j! (MdocSession$App.scala:81)
-// 2021-12-16 14:42:44 [WARN ] repl.MdocSession$App: This is not the pure woof. (MdocSession$App.scala:82)
+// 2021-12-23 10:45:47 [INFO ] repl.MdocSession$App: Hello from SLF4j! (MdocSession$App.scala:81)
+// 2021-12-23 10:45:47 [WARN ] repl.MdocSession$App: This is not the pure woof. (MdocSession$App.scala:82)
 ```
 ## Limitations of SLF4J bindings
 
@@ -184,6 +184,6 @@ the correlation ID is also returned in the header of the response.
 
 ```scala
 mainHttp4s.unsafeRunSync()
-// 2021-12-16 14:42:44 [INFO ] X-Trace-Id=a5e5846e-9de6-41c0-b29a-2050aabb8f66 repl.MdocSession$.App: I got a request with trace id! :D (.:121)
-// 2021-12-16 14:42:44 [INFO ] repl.MdocSession$.App: Got response headers: Headers(X-Trace-Id: a5e5846e-9de6-41c0-b29a-2050aabb8f66) (.:142)
+// 2021-12-23 10:45:47 [INFO ] X-Trace-Id=9b343a7d-90c5-4078-bbd6-42bd756bc15c repl.MdocSession$.App: I got a request with trace id! :D (.:121)
+// 2021-12-23 10:45:47 [INFO ] repl.MdocSession$.App: Got response headers: Headers(X-Trace-Id: 9b343a7d-90c5-4078-bbd6-42bd756bc15c) (.:142)
 ```

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,7 +12,8 @@ A **pure** _(in both senses of the word!)_ **Scala 3** logging library with **no
 * Pure **Scala 3** library
 * Made with _Cats Effect_
 * Macro based (_no runtime reflection_)
-  * Can be built for _scala.js_ in the future!
+  * ~~Can be built for _scala.js_ in the future!~~
+  * Cross-built for `Scala.js`
 * Configured with plain Scala code
 
 ## Installation
@@ -31,7 +32,7 @@ libraryDependencies ++= Seq(
 
 ```scala mdoc:silent
 import cats.effect.IO
-import org.legogroup.woof.*
+import org.legogroup.woof.{given, *}
 
 val consoleOutput: Output[IO] = new Output[IO]:
   def output(str: String)      = IO.delay(println(str))

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,7 +51,7 @@ def program(using Logger[IO]): IO[Unit] =
 
 val main: IO[Unit] = 
   for
-    given Logger[IO]  <- Logger.makeIoLogger(consoleOutput)
+    given Logger[IO]  <- DefaultLogger.makeIo(consoleOutput)
     _                 <- program
   yield ()
 ```
@@ -70,7 +70,7 @@ We can also re-use the program and add context to our logger:
 import Logger.*
 val mainWithContext: IO[Unit] = 
   for
-    given Logger[IO]  <- Logger.makeIoLogger(consoleOutput)
+    given Logger[IO]  <- DefaultLogger.makeIo(consoleOutput)
     _                 <- program.withLogContext("trace-id", "4d334544-6462-43fa-b0b1-12846f871573")
     _                 <- Logger[IO].info("Now the context is gone")
   yield ()
@@ -113,7 +113,7 @@ To use this program with woof
 import org.legogroup.woof.slf4j.*
 val mainSlf4j: IO[Unit] = 
   for
-    woofLogger  <- Logger.makeIoLogger(consoleOutput)
+    woofLogger  <- DefaultLogger.makeIo(consoleOutput)
     _           <- woofLogger.registerSlf4j
     _           <- programWithSlf4j
   yield ()
@@ -159,7 +159,7 @@ import cats.syntax.option.given
 
 val mainHttp4s: IO[Unit] = 
   for
-    given Logger[IO]  <- Logger.makeIoLogger(consoleOutput)
+    given Logger[IO]  <- DefaultLogger.makeIo(consoleOutput)
     maybeResponse     <- CorrelationIdMiddleware.middleware[IO]()(routes).run(Request[IO]()).value
     responseHeaders   =  maybeResponse.map(_.headers).orEmpty
     _                 <- Logger[IO].info(s"Got response headers: $responseHeaders")

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/Extensions.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/Extensions.scala
@@ -16,8 +16,8 @@ object Sleep:
 extension [F[_]: Concurrent: Clock: Sleep: Logger: Monad, T](f: F[T])
   inline def logConcurrently(
       every: FiniteDuration,
-  )(inline log: FiniteDuration => String, level: LogLevel = LogLevel.Debug): F[T] =
-    val doLog = repeat[F](every, log.andThen(Logger[F].log(level, _)))
+  )(inline log: FiniteDuration => String, level: LogLevel = LogLevel.Debug)(using LogInfo): F[T] =
+    val doLog = repeat[F](every, log.andThen(Logger[F].doLog(level, _)))
     Concurrent[F]
       .race(doLog, f)
       .flatMap(

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/Logger.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/Logger.scala
@@ -59,6 +59,12 @@ class DefaultLogger[F[_]: StringLocal: Monad: Clock](output: Output[F], outputs:
 
 end DefaultLogger
 
+object DefaultLogger:
+  def makeIo(output: Output[IO], outputs: Output[IO]*)(using Clock[IO], Printer, Filter): IO[DefaultLogger[IO]] =
+    for given StringLocal[IO] <- ioStringLocal
+    yield new DefaultLogger[IO](output, outputs*)
+end DefaultLogger
+
 object Logger:
 
   extension [F[_]: Logger, A](fa: F[A])
@@ -72,7 +78,12 @@ object Logger:
   given Printer = ColorPrinter()
 
   val ioStringLocal = Local.makeIoLocal[List[(String, String)]]
-  def makeIoLogger(output: Output[IO], outputs: Output[IO]*)(using Clock[IO], Printer, Filter): IO[Logger[IO]] =
+
+  @deprecated(s"Use `DefaultLogger.makeIo`") def makeIoLogger(output: Output[IO], outputs: Output[IO]*)(using
+      Clock[IO],
+      Printer,
+      Filter,
+  ): IO[Logger[IO]] =
     for given StringLocal[IO] <- ioStringLocal
     yield new DefaultLogger[IO](output, outputs*)
 

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/Logger.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/Logger.scala
@@ -14,10 +14,21 @@ import java.time.{Instant, ZoneId}
 import java.util.Locale
 import scala.util.chaining.scalaUtilChainingOps
 
-/** This is the main interface for logging. Since we use macros for the methods, we cannot abstract this with an
-  * interface. We make the class open to compensate.
-  */
-open class Logger[F[_]: StringLocal: Monad: Clock](output: Output[F], outputs: Output[F]*)(using Printer, Filter):
+trait Logger[F[_]]:
+
+  val stringLocal: StringLocal[F]
+
+  def doLog(level: LogLevel, message: String)(using logInfo: LogInfo): F[Unit]
+  def debug(message: String)(using logInfo: LogInfo): F[Unit] = doLog(LogLevel.Debug, message)
+  def info(message: String)(using logInfo: LogInfo): F[Unit]  = doLog(LogLevel.Info, message)
+  def trace(message: String)(using logInfo: LogInfo): F[Unit] = doLog(LogLevel.Trace, message)
+  def warn(message: String)(using logInfo: LogInfo): F[Unit]  = doLog(LogLevel.Warn, message)
+  def error(message: String)(using logInfo: LogInfo): F[Unit] = doLog(LogLevel.Error, message)
+
+end Logger
+
+class DefaultLogger[F[_]: StringLocal: Monad: Clock](output: Output[F], outputs: Output[F]*)(using Printer, Filter)
+    extends Logger[F]:
 
   val stringLocal: StringLocal[F] = summon[StringLocal[F]]
   val printer: Printer            = summon[Printer]
@@ -39,23 +50,14 @@ open class Logger[F[_]: StringLocal: Monad: Clock](output: Output[F], outputs: O
       case LogLevel.Error => allOutputs.traverse_(_.outputError(s))
       case _              => allOutputs.traverse_(_.output(s))
 
-  def doLog(level: LogLevel, message: String, logInfo: LogInfo): F[Unit] =
+  override def doLog(level: LogLevel, message: String)(using logInfo: LogInfo): F[Unit] =
     for
       context <- summon[StringLocal[F]].ask
       logLine <- makeLogString(level, logInfo, message, context)
       _       <- doOutputs(level, logLine).whenA(summon[Filter](LogLine(level, logInfo, logLine, context)))
     yield ()
 
-  inline def log(level: LogLevel, inline message: String): F[Unit] =
-    doLog(level, message, Macro.expressionInfo(message))
-
-  inline def debug(inline message: String): F[Unit] = log(LogLevel.Debug, message)
-  inline def info(inline message: String): F[Unit]  = log(LogLevel.Info, message)
-  inline def trace(inline message: String): F[Unit] = log(LogLevel.Trace, message)
-  inline def warn(inline message: String): F[Unit]  = log(LogLevel.Warn, message)
-  inline def error(inline message: String): F[Unit] = log(LogLevel.Error, message)
-
-end Logger
+end DefaultLogger
 
 object Logger:
 
@@ -72,6 +74,6 @@ object Logger:
   val ioStringLocal = Local.makeIoLocal[List[(String, String)]]
   def makeIoLogger(output: Output[IO], outputs: Output[IO]*)(using Clock[IO], Printer, Filter): IO[Logger[IO]] =
     for given StringLocal[IO] <- ioStringLocal
-    yield new Logger[IO](output, outputs*)
+    yield new DefaultLogger[IO](output, outputs*)
 
 end Logger

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/Logger.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/Logger.scala
@@ -18,12 +18,12 @@ trait Logger[F[_]]:
 
   val stringLocal: StringLocal[F]
 
-  def doLog(level: LogLevel, message: String)(using logInfo: LogInfo): F[Unit]
-  def debug(message: String)(using logInfo: LogInfo): F[Unit] = doLog(LogLevel.Debug, message)
-  def info(message: String)(using logInfo: LogInfo): F[Unit]  = doLog(LogLevel.Info, message)
-  def trace(message: String)(using logInfo: LogInfo): F[Unit] = doLog(LogLevel.Trace, message)
-  def warn(message: String)(using logInfo: LogInfo): F[Unit]  = doLog(LogLevel.Warn, message)
-  def error(message: String)(using logInfo: LogInfo): F[Unit] = doLog(LogLevel.Error, message)
+  def doLog(level: LogLevel, message: String)(using LogInfo): F[Unit]
+  def debug(message: String)(using LogInfo): F[Unit] = doLog(LogLevel.Debug, message)
+  def info(message: String)(using LogInfo): F[Unit]  = doLog(LogLevel.Info, message)
+  def trace(message: String)(using LogInfo): F[Unit] = doLog(LogLevel.Trace, message)
+  def warn(message: String)(using LogInfo): F[Unit]  = doLog(LogLevel.Warn, message)
+  def error(message: String)(using LogInfo): F[Unit] = doLog(LogLevel.Error, message)
 
 end Logger
 

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/Macro.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/Macro.scala
@@ -16,7 +16,7 @@ object Macro:
   private def enclosingClass(using q: Quotes)(symb: quotes.reflect.Symbol): quotes.reflect.Symbol =
     if symb.isClassDef then symb else enclosingClass(symb.owner)
 
-  private def logInfo(s: Expr[Any])(using Quotes): Expr[LogInfo] =
+  private def logInfo(using Quotes): Expr[LogInfo] =
     import quotes.reflect.*
 
     val cls      = enclosingClass(Symbol.spliceOwner)
@@ -31,6 +31,8 @@ object Macro:
     '{ LogInfo($nameExpr, $file, $lineNumber) }
   end logInfo
 
-  inline def expressionInfo(x: Any): LogInfo = ${ logInfo('x) }
+  inline given LogInfo = ${ logInfo }
 
 end Macro
+
+export Macro.given_LogInfo

--- a/modules/core/shared/src/test/scala/org/legogroup/woof/FilterSuite.scala
+++ b/modules/core/shared/src/test/scala/org/legogroup/woof/FilterSuite.scala
@@ -38,7 +38,7 @@ class FilterSuite extends CatsEffectSuite:
     given Filter = Filter.atLeastLevel(LogLevel.Warn)
     for
       stringWriter     <- newStringWriter
-      given Logger[IO] <- Logger.makeIoLogger(stringWriter)(using constantClock)
+      given Logger[IO] <- DefaultLogger.makeIo(stringWriter)(using constantClock)
       _                <- testProgram
       str              <- stringWriter.get
     yield assertEquals(str, expected)
@@ -48,7 +48,7 @@ class FilterSuite extends CatsEffectSuite:
     given Filter = Filter.regexFilter("org\\.legogroup\\.woof\\.Filter.*".r)
     for
       stringWriter     <- newStringWriter
-      given Logger[IO] <- Logger.makeIoLogger(stringWriter)(using constantClock)
+      given Logger[IO] <- DefaultLogger.makeIo(stringWriter)(using constantClock)
       _                <- testProgram
       str              <- stringWriter.get
     yield assertEquals(str.count(_ == '\n'), 4)
@@ -58,7 +58,7 @@ class FilterSuite extends CatsEffectSuite:
     given Filter = Filter.regexFilter("org.legogroup.woof\\.NotFilter.*".r)
     for
       stringWriter     <- newStringWriter
-      given Logger[IO] <- Logger.makeIoLogger(stringWriter)(using constantClock)
+      given Logger[IO] <- DefaultLogger.makeIo(stringWriter)(using constantClock)
       _                <- testProgram
       str              <- stringWriter.get
     yield assertEquals(str.count(_ == '\n'), 0)
@@ -68,7 +68,7 @@ class FilterSuite extends CatsEffectSuite:
     given Filter = Filter.exactLevel(LogLevel.Info) or Filter.exactLevel(LogLevel.Warn)
     for
       stringWriter     <- newStringWriter
-      given Logger[IO] <- Logger.makeIoLogger(stringWriter)(using constantClock)
+      given Logger[IO] <- DefaultLogger.makeIo(stringWriter)(using constantClock)
       _                <- testProgram
       str              <- stringWriter.get
     yield assertEquals(str.count(_ == '\n'), 2)

--- a/modules/http4s/src/test/scala/org/legogroup/woof/http4s/CorrelationIdMiddlewareSuite.scala
+++ b/modules/http4s/src/test/scala/org/legogroup/woof/http4s/CorrelationIdMiddlewareSuite.scala
@@ -35,7 +35,7 @@ class CorrelationIdMiddlewareSuite extends CatsEffectSuite:
 
     for
       output            <- newStringWriter
-      given Logger[IO]  <- Logger.makeIoLogger(output)
+      given Logger[IO]  <- DefaultLogger.makeIo(output)
       routesWithTraceId <- middleWare(routes).pure[IO]
       response          <- routesWithTraceId.run(Request[IO]()).value
       loggedString      <- output.get

--- a/modules/http4s/src/test/scala/org/legogroup/woof/http4s/CorrelationIdMiddlewareSuite.scala
+++ b/modules/http4s/src/test/scala/org/legogroup/woof/http4s/CorrelationIdMiddlewareSuite.scala
@@ -6,7 +6,7 @@ import cats.syntax.all.*
 import cats.{Applicative, Monad}
 import munit.CatsEffectSuite
 import org.http4s.{HttpRoutes, Request, Response}
-import org.legogroup.woof.*
+import org.legogroup.woof.{given, *}
 import org.legogroup.woof.http4s.CorrelationIdMiddleware.UUIDGen
 import org.typelevel.ci.CIString
 

--- a/modules/slf4j/src/main/scala/org/legogroup/woof/slf4j/WoofLogger.scala
+++ b/modules/slf4j/src/main/scala/org/legogroup/woof/slf4j/WoofLogger.scala
@@ -26,7 +26,7 @@ class WoofLogger(name: String) extends Logger:
 
   def getName(): String = name
 
-  private def log(level: LogLevel, msg: String) = logger.foreach(_.doLog(level, msg, getLogInfo()).unsafeRunSync())
+  private def log(level: LogLevel, msg: String) = logger.foreach(_.doLog(level, msg)(using getLogInfo()).unsafeRunSync())
   def info(msg: String): Unit                   = log(LogLevel.Info, msg)
   def debug(msg: String): Unit                  = log(LogLevel.Debug, msg)
   def error(msg: String): Unit                  = log(LogLevel.Error, msg)
@@ -83,12 +83,7 @@ class WoofLogger(name: String) extends Logger:
   def warn(x$0: org.slf4j.Marker, msg: String, objs: Array[? <: Object]): Unit   = warn(s"$msg ${objs.mkString(", ")}")
   def warn(x$0: org.slf4j.Marker, msg: String, throwable: Throwable): Unit       = warn(s"$msg ${throwable.getMessage}")
 
-  /** Since woof allows much more complex filters, the best we can do is probe the filter with the requested log level
-    * and arbitrary values in the rest of the log line.
-    */
-  private def testLevel(logLevel: LogLevel): Boolean =
-    val mockLogLine = LogLine(logLevel, LogInfo("", "", -1), "", Nil)
-    logger.exists(_.filter(mockLogLine))
+  private def testLevel(logLevel: LogLevel): Boolean = true
 
   def isDebugEnabled(): Boolean = testLevel(LogLevel.Debug)
   def isErrorEnabled(): Boolean = testLevel(LogLevel.Error)

--- a/modules/slf4j/src/test/scala/org/legogroup/woof/slf4j/Slf4jSuite.scala
+++ b/modules/slf4j/src/test/scala/org/legogroup/woof/slf4j/Slf4jSuite.scala
@@ -19,7 +19,7 @@ class Slf4jSuite extends munit.CatsEffectSuite:
     given Clock[IO] = leetClock
     for
       stringOutput <- newStringWriter
-      woofLogger   <- Logger.makeIoLogger(stringOutput)
+      woofLogger   <- DefaultLogger.makeIo(stringOutput)
       _            <- woofLogger.registerSlf4j
       slf4jLogger  <- IO.delay(LoggerFactory.getLogger(this.getClass))
       _            <- IO.delay(slf4jLogger.info("HELLO, SLF4J!"))
@@ -37,7 +37,7 @@ class Slf4jSuite extends munit.CatsEffectSuite:
     given Clock[IO] = leetClock
     for
       stringOutput <- newStringWriter
-      woofLogger   <- Logger.makeIoLogger(stringOutput)
+      woofLogger   <- DefaultLogger.makeIo(stringOutput)
       _            <- woofLogger.registerSlf4j
       slf4jLogger  <- IO.delay(LoggerFactory.getLogger(this.getClass))
       _            <- IO.delay(slf4jLogger.info("HELLO, ARRAYS!", 1, Some(42), List(1337)))
@@ -55,7 +55,7 @@ class Slf4jSuite extends munit.CatsEffectSuite:
     given Clock[IO] = leetClock
     for
       stringWriter <- newStringWriter
-      woofLogger   <- Logger.makeIoLogger(stringWriter)
+      woofLogger   <- DefaultLogger.makeIo(stringWriter)
       _            <- woofLogger.registerSlf4j
       slf4jLogger  <- IO.delay(LoggerFactory.getLogger(this.getClass))
       _            <- IO.delay(slf4jLogger.info("INFO, SLF4J!"))

--- a/modules/slf4j/src/test/scala/org/legogroup/woof/slf4j/Slf4jSuite.scala
+++ b/modules/slf4j/src/test/scala/org/legogroup/woof/slf4j/Slf4jSuite.scala
@@ -49,20 +49,24 @@ class Slf4jSuite extends munit.CatsEffectSuite:
     end for
   }
 
-  test("should check log levels") {
-    given Printer = ColorPrinter()
-    given Filter  = Filter.exactLevel(LogLevel.Warn)
+  test("should respect log levels") {
+    given Printer   = NoColorPrinter()
+    given Filter    = Filter.exactLevel(LogLevel.Warn)
+    given Clock[IO] = leetClock
     for
-      woofLogger  <- Logger.makeIoLogger(Output.fromConsole)
-      _           <- woofLogger.registerSlf4j
-      slf4jLogger <- IO.delay(LoggerFactory.getLogger(this.getClass))
-      _           <- IO.delay(slf4jLogger.info("HELLO, SLF4J!"))
-    yield
-      assert(slf4jLogger.isWarnEnabled)
-      assert(!slf4jLogger.isDebugEnabled)
-      assert(!slf4jLogger.isInfoEnabled)
-      assert(!slf4jLogger.isDebugEnabled)
-      assert(!slf4jLogger.isTraceEnabled)
+      stringWriter <- newStringWriter
+      woofLogger   <- Logger.makeIoLogger(stringWriter)
+      _            <- woofLogger.registerSlf4j
+      slf4jLogger  <- IO.delay(LoggerFactory.getLogger(this.getClass))
+      _            <- IO.delay(slf4jLogger.info("INFO, SLF4J!"))
+      _            <- IO.delay(slf4jLogger.debug("DEBUG, SLF4J!"))
+      _            <- IO.delay(slf4jLogger.warn("WARN, SLF4J!"))
+      _            <- IO.delay(slf4jLogger.error("ERROR, SLF4J!"))
+      result       <- stringWriter.get
+    yield assertEquals(
+      result,
+      "1987-05-31 13:37:00 [WARN ] org.legogroup.woof.slf4j.Slf4jSuite: WARN, SLF4J! (Slf4jSuite.scala:63)\n",
+    )
     end for
   }
 

--- a/modules/slf4j/src/test/scala/org/legogroup/woof/slf4j/Slf4jSuite.scala
+++ b/modules/slf4j/src/test/scala/org/legogroup/woof/slf4j/Slf4jSuite.scala
@@ -50,7 +50,7 @@ class Slf4jSuite extends munit.CatsEffectSuite:
   }
 
   test("should respect log levels") {
-    given Printer   = NoColorPrinter()
+    given Printer   = NoColorPrinter(testFormatTime)
     given Filter    = Filter.exactLevel(LogLevel.Warn)
     given Clock[IO] = leetClock
     for


### PR DESCRIPTION
Abstract `Logger` as a trait using a given `LogInfo` macro. The default implementaiton of `Logger` is `DefaultLogger`. 
`Logger.makeIoLogger` creates instances of `DefaultLogger`, but is mostly compatible with existing user code. We deprecate `Logger.makeIoLogger` in favor of `DefaultLogger.makeIo`.

The `slf4j` binding now always returns "true" for all `is[Level]Enabled()` calls instead of guessing -- the actual filtering is handled by the woof logger itself.
