### PR TITLE
2 allow shortening of classpath

### DIFF
--- a/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
@@ -1,18 +1,14 @@
 package org.legogroup.woof
 
-import scala.annotation.tailrec
-
 case class EnclosingClass(fullName: String, lineLength: Int = 80):
   lazy val printableName: String = reduceNameLength(fullName)
 
-  @tailrec
   private def reduceNameLength(name: String): String =
     List
       .unfold(name.split('.').toList) {
-        case Nil                                                   => none
-        case last :: Nil                                           => (last, Nil).some
-        case parts @ x :: xs if parts.mkString.length > lineLength => (x.take(1), xs).some
-        case x :: xs                                               => (x, xs).some
+        case Nil                                                   => None
+        case last :: Nil                                           => Some(last, Nil)
+        case parts @ x :: xs if parts.mkString.length > lineLength => Some(x.take(1), xs)
+        case x :: xs                                               => Some(x, xs)
       }
       .mkString(".")
-  }

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
@@ -1,0 +1,18 @@
+package org.legogroup.woof
+
+import scala.annotation.tailrec
+
+case class EnclosingClass(fullName: String):
+  private val lineLength = 80
+  def printableName: String = reduceNameLength(fullName)
+
+  @tailrec
+  private def reduceNameLength(name: String, chomps: Int = 0): String = {
+    if(name.length > lineLength) {
+      val names = name.split('.')
+      names.update(chomps, names(chomps).head.toString)
+      reduceNameLength(names.mkString("."), chomps + 1)
+    } else {
+      name
+    }
+  }

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
@@ -8,8 +8,11 @@ case class EnclosingClass(fullName: String):
 
   @tailrec
   private def reduceNameLength(name: String, chomps: Int = 0): String = {
-    if(name.length > lineLength) {
-      val names = name.split('.')
+    val names = name.split('.')
+    val isTooLong = name.length > lineLength
+    val notLastPossibleChomp = chomps < names.length
+    val keepChomping = notLastPossibleChomp && isTooLong
+    if (keepChomping) {
       names.update(chomps, names(chomps).head.toString)
       reduceNameLength(names.mkString("."), chomps + 1)
     } else {

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
@@ -6,9 +6,10 @@ case class EnclosingClass(fullName: String, lineLength: Int = 80):
   private def reduceNameLength(name: String): String =
     List
       .unfold(name.split('.').toList) {
-        case Nil                                                   => None
-        case last :: Nil                                           => Some(last, Nil)
+        case Nil                                                        => None
+        case last :: Nil                                                => Some(last, Nil)
         case parts @ x :: xs if parts.mkString(".").length > lineLength => Some(x.take(1), xs)
-        case x :: xs                                               => Some(x, xs)
+        case x :: xs                                                    => Some(x, xs)
       }
       .mkString(".")
+end EnclosingClass

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
@@ -2,15 +2,14 @@ package org.legogroup.woof
 
 import scala.annotation.tailrec
 
-case class EnclosingClass(fullName: String):
-  private val lineLength = 80
+case class EnclosingClass(fullName: String, lineLength: Int = 80):
   def printableName: String = reduceNameLength(fullName)
 
   @tailrec
   private def reduceNameLength(name: String, chomps: Int = 0): String = {
     val names = name.split('.')
     val isTooLong = name.length > lineLength
-    val notLastPossibleChomp = chomps < names.length
+    val notLastPossibleChomp = chomps < names.length - 1
     val keepChomping = notLastPossibleChomp && isTooLong
     if (keepChomping) {
       names.update(chomps, names(chomps).head.toString)

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
@@ -3,7 +3,7 @@ package org.legogroup.woof
 import scala.annotation.tailrec
 
 case class EnclosingClass(fullName: String, lineLength: Int = 80):
-  def printableName: String = reduceNameLength(fullName)
+  lazy val printableName: String = reduceNameLength(fullName)
 
   @tailrec
   private def reduceNameLength(name: String): String =

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
@@ -8,7 +8,7 @@ case class EnclosingClass(fullName: String, lineLength: Int = 80):
       .unfold(name.split('.').toList) {
         case Nil                                                   => None
         case last :: Nil                                           => Some(last, Nil)
-        case parts @ x :: xs if parts.mkString.length > lineLength => Some(x.take(1), xs)
+        case parts @ x :: xs if parts.mkString(".").length > lineLength => Some(x.take(1), xs)
         case x :: xs                                               => Some(x, xs)
       }
       .mkString(".")

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/EnclosingClass.scala
@@ -6,15 +6,13 @@ case class EnclosingClass(fullName: String, lineLength: Int = 80):
   def printableName: String = reduceNameLength(fullName)
 
   @tailrec
-  private def reduceNameLength(name: String, chomps: Int = 0): String = {
-    val names = name.split('.')
-    val isTooLong = name.length > lineLength
-    val notLastPossibleChomp = chomps < names.length - 1
-    val keepChomping = notLastPossibleChomp && isTooLong
-    if (keepChomping) {
-      names.update(chomps, names(chomps).head.toString)
-      reduceNameLength(names.mkString("."), chomps + 1)
-    } else {
-      name
-    }
+  private def reduceNameLength(name: String): String =
+    List
+      .unfold(name.split('.').toList) {
+        case Nil                                                   => none
+        case last :: Nil                                           => (last, Nil).some
+        case parts @ x :: xs if parts.mkString.length > lineLength => (x.take(1), xs).some
+        case x :: xs                                               => (x, xs).some
+      }
+      .mkString(".")
   }

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/Filter.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/Filter.scala
@@ -13,7 +13,7 @@ object Filter:
 
   val atLeastLevel: LogLevel => Filter = level => line => line.level >= level
   val exactLevel: LogLevel => Filter   = level => line => line.level == level
-  val regexFilter: Regex => Filter     = regex => line => regex.matches(line.info.enclosingClass)
+  val regexFilter: Regex => Filter     = regex => line => regex.matches(line.info.enclosingClass.fullName)
   val nothing: Filter                  = _ => false
   val everything: Filter               = _ => true
 

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/Filter.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/Filter.scala
@@ -13,7 +13,7 @@ object Filter:
 
   val atLeastLevel: LogLevel => Filter = level => line => line.level >= level
   val exactLevel: LogLevel => Filter   = level => line => line.level == level
-  val regexFilter: Regex => Filter     = regex => line => regex.matches(line.info.enclosingClass.fullName)
+  val regexFilter: Regex => Filter     = regex => line => regex.matches(line.info.enclosingClass.printableName)
   val nothing: Filter                  = _ => false
   val everything: Filter               = _ => true
 

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/LogInfo.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/LogInfo.scala
@@ -1,5 +1,5 @@
 package org.legogroup.woof
 
-case class LogInfo(enclosingClass: String, fileName: String, lineNumber: Int):
-  def prefix: String  = enclosingClass
+case class LogInfo(enclosingClass: EnclosingClass, fileName: String, lineNumber: Int):
+  def prefix: String  = enclosingClass.printableName
   def postfix: String = s"(${fileName}:${lineNumber + 1})"

--- a/modules/core/shared/src/main/scala/org/legogroup/woof/Macro.scala
+++ b/modules/core/shared/src/main/scala/org/legogroup/woof/Macro.scala
@@ -12,6 +12,11 @@ object Macro:
       val path = Expr(f.getAbsolutePath)
       '{ new java.io.File($path) }
 
+  private given ToExpr[EnclosingClass] with
+    def apply(name: EnclosingClass)(using Quotes): Expr[EnclosingClass] =
+      val exp = Expr(name.fullName)
+      '{ EnclosingClass($exp) }
+
   @tailrec
   private def enclosingClass(using q: Quotes)(symb: quotes.reflect.Symbol): quotes.reflect.Symbol =
     if symb.isClassDef then symb else enclosingClass(symb.owner)
@@ -21,7 +26,7 @@ object Macro:
 
     val cls      = enclosingClass(Symbol.spliceOwner)
     val name     = cls.fullName
-    val nameExpr = Expr(name)
+    val nameExpr = Expr(EnclosingClass(name))
 
     val position   = Position.ofMacroExpansion
     val filePath   = if position.sourceFile.jpath != null then position.sourceFile.jpath else Paths.get(".")

--- a/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
+++ b/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
@@ -1,0 +1,49 @@
+package org.legogroup.woof
+
+import cats.Applicative
+import cats.effect.{Clock, IO}
+import cats.instances.string
+import cats.kernel.Monoid
+import cats.syntax.all.*
+import munit.{CatsEffectSuite, FunSuite}
+import org.legogroup.woof.Filter.given_Monoid_Filter
+import org.legogroup.woof.Logger.*
+
+import java.time.format.DateTimeFormatter
+import java.time.{Instant, ZoneId}
+import scala.concurrent.duration.*
+class EnclosingClassSuite extends CatsEffectSuite:
+
+  class ThisClassNameIsReallyLongAndWillTriggerParentPackageAbbreviation:
+    val startTime = 549459420.seconds
+
+    val constantClock: Clock[IO] = new Clock[IO]:
+      def applicative = Applicative[IO]
+      def monotonic   = startTime.pure
+      def realTime    = startTime.pure
+
+    def testProgram(using Logger[IO]): IO[Unit] =
+      for
+        _ <- Logger[IO].info("Info message")
+        _ <- Logger[IO].debug("Debug message")
+        _ <- Logger[IO].warn("Warning message")
+        _ <- Logger[IO].error("Error message")
+      yield ()
+  end ThisClassNameIsReallyLongAndWillTriggerParentPackageAbbreviation
+
+  given Filter = Filter.everything
+  given Printer = NoColorPrinter(testFormatTime)
+
+  test("class names abbreviated when too long") {
+    val expected = "o.l.w.E.ThisClassNameIsReallyLongAndWillTriggerParentPackageAbbreviation"
+    val testClass = new ThisClassNameIsReallyLongAndWillTriggerParentPackageAbbreviation
+    for
+      stringWriter     <- newStringWriter
+      given Logger[IO] <- Logger.makeIoLogger(stringWriter)(using testClass.constantClock)
+      _                <- testClass.testProgram
+      str              <- stringWriter.get
+    yield assert(str.contains(expected))
+  }
+
+end EnclosingClassSuite
+

--- a/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
+++ b/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
@@ -39,5 +39,13 @@ class EnclosingClassSuite extends CatsEffectSuite:
     yield assert(str.contains(expected))
   }
 
+  test("terminates when package depth is really deep") {
+    assertEquals(EnclosingClass("never.gonna.give.you.up", 1).printableName, "n.g.g.y.up")
+  }
+
+  test("does not abbreviate package if too short") {
+    assertEquals(EnclosingClass("Too.$hort", 10).printableName, "Too.$hort")
+  }
+
 end EnclosingClassSuite
 

--- a/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
+++ b/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
@@ -39,7 +39,7 @@ class EnclosingClassSuite extends CatsEffectSuite:
     val testClass = new ThisClassNameIsReallyLongAndWillTriggerParentPackageAbbreviation
     for
       stringWriter     <- newStringWriter
-      given Logger[IO] <- Logger.makeIoLogger(stringWriter)(using testClass.constantClock)
+      given Logger[IO] <- DefaultLogger.makeIo(stringWriter)(using testClass.constantClock)
       _                <- testClass.testProgram
       str              <- stringWriter.get
     yield assert(str.contains(expected))

--- a/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
+++ b/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
@@ -39,7 +39,7 @@ class EnclosingClassSuite extends CatsEffectSuite:
     yield assert(str.contains(expected))
   }
 
-  test("terminates when package depth is really deep") {
+  test("does not abbreviate last term if depth is really deep") {
     assertEquals(EnclosingClass("never.gonna.give.you.up", 1).printableName, "n.g.g.y.up")
   }
 

--- a/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
+++ b/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
@@ -48,7 +48,7 @@ class EnclosingClassSuite extends CatsEffectSuite:
   }
 
   test("partially chomped") {
-    assertEquals(EnclosingClass("never.gonna.give.you.up", 10).printableName, "n.g.give.you.up")
+    assertEquals(EnclosingClass("never.gonna.give.you.up", 15).printableName, "n.g.give.you.up")
   }
 
 end EnclosingClassSuite

--- a/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
+++ b/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
@@ -15,12 +15,6 @@ import scala.concurrent.duration.*
 class EnclosingClassSuite extends CatsEffectSuite:
 
   class ThisClassNameIsReallyLongAndWillTriggerParentPackageAbbreviation:
-    val startTime = 549459420.seconds
-
-    val constantClock: Clock[IO] = new Clock[IO]:
-      def applicative = Applicative[IO]
-      def monotonic   = startTime.pure
-      def realTime    = startTime.pure
 
     def testProgram(using Logger[IO]): IO[Unit] =
       for
@@ -39,7 +33,7 @@ class EnclosingClassSuite extends CatsEffectSuite:
     val testClass = new ThisClassNameIsReallyLongAndWillTriggerParentPackageAbbreviation
     for
       stringWriter     <- newStringWriter
-      given Logger[IO] <- DefaultLogger.makeIo(stringWriter)(using testClass.constantClock)
+      given Logger[IO] <- DefaultLogger.makeIo(stringWriter)(using leetClock)
       _                <- testClass.testProgram
       str              <- stringWriter.get
     yield assert(str.contains(expected))

--- a/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
+++ b/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
@@ -46,8 +46,10 @@ class EnclosingClassSuite extends CatsEffectSuite:
   test("does not abbreviate package if too short") {
     assertEquals(EnclosingClass("Too.$hort", 10).printableName, "Too.$hort")
   }
+
   test("partially chomped") {
     assertEquals(EnclosingClass("never.gonna.give.you.up", 10).printableName, "n.g.give.you.up")
   }
+
 end EnclosingClassSuite
 

--- a/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
+++ b/modules/core/shared/src/test/scala/org/legogroup/woof/EnclosingClassSuite.scala
@@ -46,6 +46,8 @@ class EnclosingClassSuite extends CatsEffectSuite:
   test("does not abbreviate package if too short") {
     assertEquals(EnclosingClass("Too.$hort", 10).printableName, "Too.$hort")
   }
-
+  test("partially chomped") {
+    assertEquals(EnclosingClass("never.gonna.give.you.up", 10).printableName, "n.g.give.you.up")
+  }
 end EnclosingClassSuite
 

--- a/modules/slf4j/src/main/scala/org/legogroup/woof/slf4j/WoofLogger.scala
+++ b/modules/slf4j/src/main/scala/org/legogroup/woof/slf4j/WoofLogger.scala
@@ -15,24 +15,24 @@ class WoofLogger(name: String) extends Logger:
   private def getLogInfo() =
     val stacktraceElements = Thread.currentThread().getStackTrace()
     val callingMethodIndex =
-      stacktraceElements.size - stacktraceElements.reverse.indexWhere(s =>
-        s.getClassName == this.getClass.getName,
+      stacktraceElements.size - stacktraceElements.reverse.indexWhere(s => s.getClassName == this.getClass.getName,
       ) // after last mention of this class
     val callingMethod: StackTraceElement = stacktraceElements(callingMethodIndex)
     val enclosingClassName               = EnclosingClass(callingMethod.getClassName)
-    val fileName                         = (enclosingClassName.fullName.replace('.', '/') + ".scala").split("\\/").takeRight(1).mkString
-    val lineNumber                       = callingMethod.getLineNumber - 1
+    val fileName   = (enclosingClassName.fullName.replace('.', '/') + ".scala").split("\\/").takeRight(1).mkString
+    val lineNumber = callingMethod.getLineNumber - 1
     LogInfo(enclosingClassName, fileName, lineNumber)
   end getLogInfo
 
   def getName(): String = name
 
-  private def log(level: LogLevel, msg: String) = logger.foreach(_.doLog(level, msg)(using getLogInfo()).unsafeRunSync())
-  def info(msg: String): Unit                   = log(LogLevel.Info, msg)
-  def debug(msg: String): Unit                  = log(LogLevel.Debug, msg)
-  def error(msg: String): Unit                  = log(LogLevel.Error, msg)
-  def trace(msg: String): Unit                  = log(LogLevel.Trace, msg)
-  def warn(msg: String): Unit                   = log(LogLevel.Warn, msg)
+  private def log(level: LogLevel, msg: String) =
+    logger.foreach(_.doLog(level, msg)(using getLogInfo()).unsafeRunSync())
+  def info(msg: String): Unit  = log(LogLevel.Info, msg)
+  def debug(msg: String): Unit = log(LogLevel.Debug, msg)
+  def error(msg: String): Unit = log(LogLevel.Error, msg)
+  def trace(msg: String): Unit = log(LogLevel.Trace, msg)
+  def warn(msg: String): Unit  = log(LogLevel.Warn, msg)
 
   def debug(msg: String, obj: Object): Unit                        = debug(s"$msg $obj")
   def debug(msg: String, obj1: Object, obj2: Object): Unit         = debug(s"$msg $obj1, $obj2")


### PR DESCRIPTION
Creates an `EnclosingClass` type and replaces the `LogInfo::enclosingClass:String` member.

If the fully qualified class name is longer than the configured max length, then the full class name will be reduced until only the local class name remains.

Two points of discussion immediately jump out

- `EnclosingClass` name was picked since that was the member name and I am bad at naming things.  I am open to suggestions
- Default length for abbreviation to kick in is 80 characters.  Configurable and easy to change.

Closes: #2