### PR TITLE
Add incubator module

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -4,12 +4,12 @@ runner.dialect = scala3
 
 maxColumn = 120
 align.preset = more
-rewrite.rules = [RedundantBraces, SortImports]
+rewrite.rules = [RedundantBraces, Imports]
 binPack.literalArgumentLists = false
 trailingCommas = keep
 rewrite.scala3.convertToNewSyntax = true
 rewrite.scala3.removeOptionalBraces = true
-rewrite.scala3.insertEndMarkerMinLines = 10
+rewrite.scala3.insertEndMarkerMinLines = 20
 rewrite.redundantBraces.ifElseExpressions = true
 
 fileOverride {

--- a/build.sbt
+++ b/build.sbt
@@ -72,7 +72,7 @@ lazy val docs =
 lazy val root =
   project
     .in(file("."))
-    .aggregate(core.jvm, core.js, http4s.jvm, http4s.js, slf4j)
+    .aggregate(core.jvm, core.js, http4s.jvm, http4s.js, slf4j, incubator.js, incubator.jvm)
     .settings(
       publish / skip := true,
     )
@@ -108,3 +108,13 @@ lazy val http4s = crossProject(JSPlatform, JVMPlatform)
 lazy val slf4j = woofProject(file("./modules/slf4j"))
   .settings(libraryDependencies += D.slf4jApi)
   .dependsOn(core.jvm % "compile->compile;test->test")
+
+val incubatorFolder = file("./modules/incubator")
+lazy val incubator = crossProject(JSPlatform, JVMPlatform)
+  .crossType(CrossType.Pure)
+  .in(incubatorFolder)
+  .settings(
+    name := nameForFile(incubatorFolder)
+  )
+  .settings(commonSettings)
+  .dependsOn(core % "compile->compile;test->test")

--- a/modules/core/shared/src/test/scala/org/legogroup/woof/LoggerSuite.scala
+++ b/modules/core/shared/src/test/scala/org/legogroup/woof/LoggerSuite.scala
@@ -17,20 +17,14 @@ import scala.jdk.CollectionConverters.*
 class LoggerSuite extends CatsEffectSuite:
 
   given Filter = Filter.everything
-
   def clockOf(ref: Ref[IO, FiniteDuration]): Clock[IO] = new Clock[IO]:
     def applicative = Applicative[IO]
     def monotonic   = ref.get
     def realTime    = ref.get
 
-  val constantClock: Clock[IO] = new Clock[IO]:
-    def applicative = Applicative[IO]
-    def monotonic   = startTime.pure
-    def realTime    = startTime.pure
-
   test("log should make log line") {
 
-    given Clock[IO] = constantClock
+    given Clock[IO] = leetClock
     given Printer   = NoColorPrinter(testFormatTime)
 
     val message  = "log message"
@@ -46,7 +40,7 @@ class LoggerSuite extends CatsEffectSuite:
 
   test("log should log in colors") {
 
-    given Clock[IO]   = constantClock
+    given Clock[IO]   = leetClock
     val theme         = Theme.defaultTheme
     given Printer     = ColorPrinter(theme = theme, formatTime = testFormatTime)
     val reset         = Theme.Style.Reset
@@ -88,7 +82,7 @@ class LoggerSuite extends CatsEffectSuite:
   }
 
   test("Should use local context") {
-    given Clock[IO] = constantClock
+    given Clock[IO] = leetClock
     given Printer   = NoColorPrinter(testFormatTime)
 
     val message = "log message"

--- a/modules/core/shared/src/test/scala/org/legogroup/woof/LoggerSuite.scala
+++ b/modules/core/shared/src/test/scala/org/legogroup/woof/LoggerSuite.scala
@@ -29,7 +29,7 @@ class LoggerSuite extends CatsEffectSuite:
 
     val message  = "log message"
     val logInfo  = summon[LogInfo]
-    val expected = "1987-05-31 13:37:00 [WARN ] org.legogroup.woof.LoggerSuite: log message (LoggerSuite.scala:37)"
+    val expected = "1987-05-31 13:37:00 [WARN ] org.legogroup.woof.LoggerSuite: log message (LoggerSuite.scala:31)"
 
     for
       given StringLocal[IO] <- ioStringLocal
@@ -46,7 +46,7 @@ class LoggerSuite extends CatsEffectSuite:
     val reset         = Theme.Style.Reset
     val postfixFormat = theme.postfixFormat
     // format: off
-    val expected = s"""1987-05-31 13:37:00 ${theme.levelFormat(LogLevel.Warn)}[WARN ]$reset ${postfixFormat}org.legogroup.woof.LoggerSuite$reset: This is a warning $postfixFormat(LoggerSuite.scala:62)$reset
+    val expected = s"""1987-05-31 13:37:00 ${theme.levelFormat(LogLevel.Warn)}[WARN ]$reset ${postfixFormat}org.legogroup.woof.LoggerSuite$reset: This is a warning $postfixFormat(LoggerSuite.scala:56)$reset
 """
     // format: on
     for
@@ -75,7 +75,7 @@ class LoggerSuite extends CatsEffectSuite:
     yield assertEquals(
       logs.split("\n").toList,
       List(0, 200, 400, 600, 800)
-        .map(t => s"1987-05-31 13:37:00 [DEBUG] org.legogroup.woof.LoggerSuite: $t elapsed (LoggerSuite.scala:79)")
+        .map(t => s"1987-05-31 13:37:00 [DEBUG] org.legogroup.woof.LoggerSuite: $t elapsed (LoggerSuite.scala:73)")
     )
 
     executeWithStartTime(program)
@@ -91,8 +91,8 @@ class LoggerSuite extends CatsEffectSuite:
     def programLogic(using Logger[IO]) = Logger[IO].info("some info")
 
     // format: off
-    val expected = """1987-05-31 13:37:00 [INFO ] correlation-id=21c78595-ef21-4df0-987e-8af6aab6f346, locale=da-DK org.legogroup.woof.LoggerSuite: some info (LoggerSuite.scala:97)
-1987-05-31 13:37:00 [INFO ] org.legogroup.woof.LoggerSuite: some info (LoggerSuite.scala:97)
+    val expected = """1987-05-31 13:37:00 [INFO ] correlation-id=21c78595-ef21-4df0-987e-8af6aab6f346, locale=da-DK org.legogroup.woof.LoggerSuite: some info (LoggerSuite.scala:91)
+1987-05-31 13:37:00 [INFO ] org.legogroup.woof.LoggerSuite: some info (LoggerSuite.scala:91)
 """
     // format: on
     for

--- a/modules/incubator/src/main/scala/org/legogroup/woof/incubator/extensions/Extensions.scala
+++ b/modules/incubator/src/main/scala/org/legogroup/woof/incubator/extensions/Extensions.scala
@@ -1,0 +1,94 @@
+package org.legogroup.woof.incubator.extensions
+
+import org.legogroup.woof.{Logger, repeatAtFixedRate, LogLevel, LogInfo, given}
+import cats.{Applicative, Parallel}
+import cats.effect.{Concurrent, Ref}
+import cats.syntax.all.*
+import cats.effect.syntax.all.*
+import scala.concurrent.duration.*
+import scala.annotation.tailrec
+import org.legogroup.woof.Sleep
+import cats.syntax.all.*
+import cats.Monad
+import cats.effect.kernel.Clock
+import cats.Show
+
+def repeat[F[_]: Sleep: Monad](every: FiniteDuration, f: F[Unit]): F[Unit] =
+  for
+    _ <- Sleep[F].sleep(every)
+    _ <- f
+    _ <- repeat(every, f)
+  yield ()
+
+extension [F[_]: Logger: Monad, T](f: F[T])
+  private inline def log(msg: T => String, level: LogLevel)(using LogInfo): F[T] =
+    f.flatTap(m => Logger[F].doLog(level, msg(m)))
+
+  inline def debug(msg: T => String): F[T] = log(msg, LogLevel.Debug)
+  inline def error(msg: T => String): F[T] = log(msg, LogLevel.Error)
+  inline def info(msg: T => String): F[T]  = log(msg, LogLevel.Info)
+  inline def trace(msg: T => String): F[T] = log(msg, LogLevel.Trace)
+  inline def warn(msg: T => String): F[T]  = log(msg, LogLevel.Warn)
+
+extension [F[_]: Logger: Monad, T: Show](f: F[T])
+  private inline def logShow(level: LogLevel)(using LogInfo): F[T] =
+    f.flatTap(t => Logger[F].doLog(level, Show[T].show(t)))
+
+  inline def debugShow: F[T] = logShow(LogLevel.Debug)
+  inline def errorShow: F[T] = logShow(LogLevel.Error)
+  inline def infoShow: F[T]  = logShow(LogLevel.Info)
+  inline def traceShow: F[T] = logShow(LogLevel.Trace)
+  inline def warnShow: F[T]  = logShow(LogLevel.Warn)
+
+extension [A](as: List[A])
+  inline def traverseLog[B, G[_]: Logger: Applicative](g: A => G[B], msg: (A, Double) => String): G[List[B]] =
+    val n = as.length
+    as.zipWithIndex.traverse((a, i) => g(a) <* Logger[G].debug(msg(a, (i + 1).toDouble / n.toDouble * 100d)))
+
+  inline def parTraverseLog[B, G[_]: Parallel: Concurrent: Logger: Applicative](parallelism: Int)(
+      g: A => G[B],
+      msg: (A, Double) => String,
+  ): G[List[B]] =
+    val n = as.length
+    for
+      ref <- Ref[G].of(0)
+      result <- as.parTraverseN(parallelism)(a =>
+        for
+          result  <- g(a)
+          updated <- ref.updateAndGet(_ + 1)
+          _       <- Logger[G].debug(msg(a, updated.toDouble / n.toDouble * 100d))
+        yield result,
+      )
+    yield result
+    end for
+  end parTraverseLog
+
+  inline def parTraverseLogProgress[B, G[_]: Clock: Sleep: Parallel: Concurrent: Logger: Applicative](
+      parallelism: Int,
+      every: FiniteDuration
+  )(
+      g: A => G[B],
+      msg: Double => String,
+  ) =
+    val n = as.length
+    for
+      ref <- Ref[G].of(0)
+      logfiber <- repeat(
+        every,
+        ref.get.flatMap(d => Logger[G].debug(msg(d.toDouble / as.length.toDouble * 100d)))
+      ).start
+      result <- as
+        .parTraverseN(parallelism)(a =>
+          for
+            result <- g(a)
+            _      <- ref.update(_ + 1)
+          yield result
+        )
+        .start
+      rj <- result.join
+      _  <- logfiber.cancel
+    yield rj
+    end for
+  end parTraverseLogProgress
+
+end extension

--- a/modules/incubator/src/main/scala/org/legogroup/woof/incubator/extensions/Extensions.scala
+++ b/modules/incubator/src/main/scala/org/legogroup/woof/incubator/extensions/Extensions.scala
@@ -45,10 +45,9 @@ extension [A](as: List[A])
     val n = as.length
     as.zipWithIndex.traverse((a, i) => g(a) <* Logger[G].debug(msg(a, (i + 1).toDouble / n.toDouble * 100d)))
 
-  inline def parTraverseLog[B, G[_]: Parallel: Concurrent: Logger: Applicative](parallelism: Int)(
-      g: A => G[B],
-      msg: (A, Double) => String,
-  ): G[List[B]] =
+  inline def parTraverseLog[B, G[_]: Parallel: Concurrent: Logger: Applicative](
+      parallelism: Int
+  )(g: A => G[B], msg: (A, Double) => String): G[List[B]] =
     val n = as.length
     for
       ref <- Ref[G].of(0)
@@ -69,7 +68,7 @@ extension [A](as: List[A])
   )(
       g: A => G[B],
       msg: Double => String,
-  ) =
+  ): G[List[B]] =
     val n = as.length
     for
       ref <- Ref[G].of(0)
@@ -85,7 +84,7 @@ extension [A](as: List[A])
           yield result
         )
         .start
-      rj <- result.join
+      rj <- result.joinWithNever
       _  <- logfiber.cancel
     yield rj
     end for

--- a/modules/incubator/src/test/scala/org/legogroup/woof/incubator/extensions/ExtensionsSuite.scala
+++ b/modules/incubator/src/test/scala/org/legogroup/woof/incubator/extensions/ExtensionsSuite.scala
@@ -1,0 +1,96 @@
+package org.legogroup.woof.incubator.extensions
+
+import munit.CatsEffectSuite
+import org.legogroup.woof.{*, given}
+import cats.effect.IO
+import cats.syntax.all.*
+import cats.instances.string
+import cats.effect.kernel.Clock
+import scala.concurrent.duration.*
+class ExtensionsSuite extends CatsEffectSuite:
+
+  given Filter  = Filter.everything
+  given Printer = NoColorPrinter()
+
+  test("log methods directly on F") {
+
+    given Clock[IO] = leetClock
+
+    val ioValue = IO.pure("foo")
+
+    for
+      stringWriter     <- newStringWriter
+      given Logger[IO] <- DefaultLogger.makeIo(stringWriter)
+      _                <- ioValue.infoShow
+      logs             <- stringWriter.get
+    yield assertEquals(logs, "1987-05-31 13:37:00 [INFO ] org.legogroup.woof.incubator.extensions.ExtensionsSuite: foo (ExtensionsSuite.scala:24)\n")
+
+  }
+
+  test("traverselog") {
+    val items = List("foo", "bar", "baz")
+
+    val expected = List(
+      "33.33%",
+      "66.67%",
+      "100.00%"
+    ).zip(items)
+      .map((p, n) =>
+        s"1987-05-31 13:37:00 [DEBUG] org.legogroup.woof.incubator.extensions.ExtensionsSuite: Item $n, $p (ExtensionsSuite.scala:47)"
+      )
+      .mkString("", "\n", "\n")
+
+    given Clock[IO] = leetClock
+    for
+      stringWriter     <- newStringWriter
+      given Logger[IO] <- DefaultLogger.makeIo(stringWriter)
+      _                <- items.traverseLog(_.pure[IO], (item, percentage) => f"Item $item, $percentage%.2f%%")
+      logs             <- stringWriter.get
+    yield assertEquals(logs, expected)
+
+  }
+
+  test("parTraverselog") {
+    val items = List("foo", "bar", "baz")
+
+    val expected = List(
+      "33.33%",
+      "66.67%",
+      "100.00%"
+    )
+
+    val program = for
+      stringWriter     <- newStringWriter
+      given Logger[IO] <- DefaultLogger.makeIo(stringWriter)
+      _                <- items.parTraverseLog(2)(_.pure[IO], (item, percentage) => f"Item $item, $percentage%.2f%%")
+      logs             <- stringWriter.get
+    yield expected.foreach(p => assert(logs.contains(p), s"should contain $p"))
+
+    executeWithStartTime(program)
+  }
+
+  test("parTraverseLogProgress") {
+    val items = List(5, 5, 5)
+    val expected = List(
+      ("0.00%", "04"),
+      ("33.33%", "09"),
+      ("66.67%", "14")
+    ).map((p, s) =>
+      s"1987-05-31 13:37:$s [DEBUG] org.legogroup.woof.incubator.extensions.ExtensionsSuite: Progress is now at: $p (ExtensionsSuite.scala:86)"
+    ).mkString("", "\n", "\n")
+
+    given Sleep[IO] = IO.sleep
+    val program = for
+      stringWriter     <- newStringWriter
+      given Logger[IO] <- DefaultLogger.makeIo(stringWriter)
+      _ <- items.parTraverseLogProgress(parallelism = 1, every = 4.9.seconds)(
+        i => IO.sleep(i.seconds),
+        d => f"Progress is now at: $d%.2f%%"
+      )
+      logs <- stringWriter.get
+    yield assertEquals(logs, expected)
+
+    executeWithStartTime(program)
+  }
+
+end ExtensionsSuite

--- a/modules/incubator/src/test/scala/org/legogroup/woof/incubator/extensions/ExtensionsSuite.scala
+++ b/modules/incubator/src/test/scala/org/legogroup/woof/incubator/extensions/ExtensionsSuite.scala
@@ -49,7 +49,7 @@ class ExtensionsSuite extends CatsEffectSuite:
       given Logger[IO] <- DefaultLogger.makeIo(stringWriter)
       _                <- items.traverseLog(_.pure[IO], (item, percentage) => f"Item $item, $percentage%.2f%%")
       logs             <- stringWriter.get
-    yield assertEquals(logs, expected)
+    yield assertEquals(logs, expected),
 
   }
 
@@ -65,7 +65,7 @@ class ExtensionsSuite extends CatsEffectSuite:
     val program = for
       stringWriter     <- newStringWriter
       given Logger[IO] <- DefaultLogger.makeIo(stringWriter)
-      _                <- items.parTraverseLog(2)(_.pure[IO], (item, percentage) => f"Item $item, $percentage%.2f%%")
+      result           <- items.parTraverseLog(2)(IO.pure, (item, percentage) => f"Item $item, $percentage%.2f%%")
       logs             <- stringWriter.get
     yield expected.foreach(p => assert(logs.contains(p), s"should contain $p"))
 

--- a/modules/incubator/src/test/scala/org/legogroup/woof/incubator/extensions/ExtensionsSuite.scala
+++ b/modules/incubator/src/test/scala/org/legogroup/woof/incubator/extensions/ExtensionsSuite.scala
@@ -10,7 +10,7 @@ import scala.concurrent.duration.*
 class ExtensionsSuite extends CatsEffectSuite:
 
   given Filter  = Filter.everything
-  given Printer = NoColorPrinter()
+  given Printer = NoColorPrinter(testFormatTime)
 
   test("log methods directly on F") {
 
@@ -23,7 +23,10 @@ class ExtensionsSuite extends CatsEffectSuite:
       given Logger[IO] <- DefaultLogger.makeIo(stringWriter)
       _                <- ioValue.infoShow
       logs             <- stringWriter.get
-    yield assertEquals(logs, "1987-05-31 13:37:00 [INFO ] org.legogroup.woof.incubator.extensions.ExtensionsSuite: foo (ExtensionsSuite.scala:24)\n")
+    yield assertEquals(
+      logs,
+      "1987-05-31 13:37:00 [INFO ] org.legogroup.woof.incubator.extensions.ExtensionsSuite: foo (ExtensionsSuite.scala:24)\n"
+    )
 
   }
 
@@ -36,7 +39,7 @@ class ExtensionsSuite extends CatsEffectSuite:
       "100.00%"
     ).zip(items)
       .map((p, n) =>
-        s"1987-05-31 13:37:00 [DEBUG] org.legogroup.woof.incubator.extensions.ExtensionsSuite: Item $n, $p (ExtensionsSuite.scala:47)"
+        s"1987-05-31 13:37:00 [DEBUG] org.legogroup.woof.incubator.extensions.ExtensionsSuite: Item $n, $p (ExtensionsSuite.scala:50)"
       )
       .mkString("", "\n", "\n")
 
@@ -76,7 +79,7 @@ class ExtensionsSuite extends CatsEffectSuite:
       ("33.33%", "09"),
       ("66.67%", "14")
     ).map((p, s) =>
-      s"1987-05-31 13:37:$s [DEBUG] org.legogroup.woof.incubator.extensions.ExtensionsSuite: Progress is now at: $p (ExtensionsSuite.scala:86)"
+      s"1987-05-31 13:37:$s [DEBUG] org.legogroup.woof.incubator.extensions.ExtensionsSuite: Progress is now at: $p (ExtensionsSuite.scala:89)"
     ).mkString("", "\n", "\n")
 
     given Sleep[IO] = IO.sleep


### PR DESCRIPTION
This adds a new module -- `incubator` -- which adds new functionality to woof which needs to be tried out in code before we can decide if it should move to core.

The idea is that this module is in flux, and **it can change even on patch releases**. Extensions that we like can then be moved into `core` when we decide they are useful enough.

Should be merged after https://github.com/LEGO/woof/pull/52