### PR TITLE
Publish slf4jCommon module

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -82,7 +82,8 @@ lazy val root =
         core,
         http4s,
         slf4j,
-        slf4j2
+        slf4j2,
+        slf4jCommon,
       ).flatMap(_.componentProjects).map(_.project): _*
     )
     .settings(


### PR DESCRIPTION
The 0.5.0 release does not include the woof-slf4j-common artifacts. Adding it to the root project aggregation.
```
[error] (update) sbt.librarymanagement.ResolveException: Error downloading org.legogroup:woof-slf4j-common_3:0.5.0
```

Before: 
```
~/C/r/woof ❯❯❯ sbt publishLocal | grep woof-slf4j-common_3
~/C/r/woof ❯❯❯
```

After
```
~/C/r/woof ❯❯❯ sbt publishLocal | grep woof-slf4j-common_3                                                         
[info] Wrote /Users/rgueldemeister/Code/rgueldem/woof/modules/slf4j-common/target/scala-3.2.2/woof-slf4j-common_3-0.0.0+234-bc823599-SNAPSHOT.pom
[info] :: delivering :: org.legogroup#woof-slf4j-common_3;0.0.0+234-bc823599-SNAPSHOT :: 0.0.0+234-bc823599-SNAPSHOT :: integration :: Mon Mar 20 11:30:02 MDT 2023
[info] 	published woof-slf4j-common_3 to /Users/...
```