### PR TITLE
Update release to uses environment:

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "daily"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-22.04
+    environment: Maven Central Release
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
so that it has access to the secrets configured there as well as the protection rules for releases.

Also added a base GitHub actions configuration for Dependabot.